### PR TITLE
do not allow negative keepChars value

### DIFF
--- a/term.go
+++ b/term.go
@@ -110,9 +110,9 @@ var stylesMap = map[uint8]termbox.Attribute{
 }
 
 func (v *viewer) replaceWithKeptChars(chars []rune, attrs []ansi.RuneAttr, data ansi.Astring) ([]rune, []ansi.RuneAttr) {
-	if v.keepChars != 0 && !v.wrap {
+	if v.keepChars > 0 && !v.wrap {
 		shift := min(v.hOffset, v.keepChars)
-		if v.keepChars != 0 {
+		if v.keepChars > 0 {
 			if shift < len(chars) {
 				chars = chars[shift:]
 				attrs = attrs[shift:]
@@ -515,7 +515,7 @@ func (v *viewer) processInfobarRequest(search infobarRequest) {
 		v.nextSearch(false)
 	case ibModeKeepCharacters:
 		keep, err := strconv.Atoi(string(search.str))
-		if err != nil {
+		if err != nil || keep < 0 {
 			logging.Debug("Err: Keepchar: ", err)
 			v.keepChars = 0
 		} else {


### PR DESCRIPTION
this prevents an error when you specify a negative value for "keep N first characters"

```
panic: runtime error: slice bounds out of range

goroutine 1 [running]:
panic(0x507440, 0xc42000c190)
        /usr/local/go/src/runtime/panic.go:500 +0x1a1
main.(*viewer).replaceWithKeptChars(0xc4200d4000, 0xc4200907c0, 0x10, 0x10, 0xc420072840, 0x10, 0x10, 0xc4200907c0, 0x10, 0x10, ...)
        /home/dv/git/slit/term.go:117 +0x4a0
main.(*viewer).draw(0xc4200d4000)
        /home/dv/git/slit/term.go:162 +0x15c
main.(*viewer).processInfobarRequest(0xc4200d4000, 0xc420426060, 0x2, 0x2, 0x6)
        /home/dv/git/slit/term.go:525 +0x169
main.(*viewer).termGui(0xc4200d4000)
        /home/dv/git/slit/term.go:404 +0x4ae
main.main()
        /home/dv/git/slit/slit.go:140 +0x36f
```