### PR TITLE
check if file could be read

### DIFF
--- a/slit.go
+++ b/slit.go
@@ -50,7 +50,7 @@ type Config struct {
 	historyPath   string
 	stdin         bool
 	stdinFinished chan struct{}
-	follow bool
+	follow        bool
 }
 
 var config Config
@@ -66,14 +66,15 @@ func (c *Config) isStdinRead() bool {
 }
 
 const VERSION = "1.1.2"
+
 func main() {
 	flag.StringVarP(&config.outPath, "output", "O", "", "Sets stdin cache location, if not set tmp file used, if set file preserved")
 	flag.BoolVar(&logging.Config.Enabled, "debug", false, "Enables debug messages, written to /tmp/slit.log")
-	flag.BoolVarP(&config.follow, "follow", "f",false, "Will follow file/stdin")
+	flag.BoolVarP(&config.follow, "follow", "f", false, "Will follow file/stdin")
 	showVersion := false
 	flag.BoolVar(&showVersion, "version", false, "Print version")
 	flag.Parse()
-	if showVersion{
+	if showVersion {
 		fmt.Println("Slit Version: ", VERSION)
 		os.Exit(0)
 	}

--- a/slit.go
+++ b/slit.go
@@ -131,6 +131,23 @@ func main() {
 			os.Exit(1)
 		}
 		filename := flag.Arg(0)
+		fi, err := os.Stat(filename)
+		if os.IsNotExist(err) {
+			fmt.Fprintln(os.Stderr, filename+": No such file or directory")
+			os.Exit(1)
+		} else if os.IsPermission(err) {
+			fmt.Fprintln(os.Stderr, filename+": Permission denied")
+			os.Exit(1)
+		}
+		check(err)
+		switch fmode := fi.Mode(); {
+		case fmode.IsDir():
+			fmt.Fprintln(os.Stderr, filename+" is a directory")
+			os.Exit(1)
+		case !fmode.IsRegular():
+			fmt.Fprintln(os.Stderr, filename+" is not a regular file")
+			os.Exit(1)
+		}
 		f, err = os.Open(filename)
 		check(err)
 		defer f.Close()


### PR DESCRIPTION
show more user friendly error, when file

- is not exist
- is not permitted for some reasons
- is a directory or not a regular file

`less`, `more` and probably other pagers do this either.