### PR TITLE
avoid an indefinite loop in refreshIfEmpty()

### DIFF
--- a/term.go
+++ b/term.go
@@ -502,7 +502,7 @@ loop:
 			locked = false
 			if config.stdin && config.isStdinRead() {
 				refresh()
-				break
+				break loop
 			}
 			delay = time.Duration(min64(int64(4000*time.Millisecond), int64(delay*2)))
 			refresh()


### PR DESCRIPTION
if you pass something through the pipe, e.g. `echo something | ./slit`, cpu activity suddenly increases, because the `break` without label `loop` in refreshIfEmpty() function breaks `switch` operator only and slit hangs. I assume, that if `config.isStdinRead()` is true, we don't need to wait the stdin data anymore and we can leave cycle with `break loop`.