### PR TITLE
fix a bug in the replaceWithKeptChars function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea
 .DS_Store
 *.log
+*.sw[pno]
 slit_windows_amd64.exe
 slit_windows_386.exe
 slit_darwin_386


### PR DESCRIPTION
how to reproduce a bug:

- prepare the regular file with at least one line which is longer than a half of the screen (the last is the current feature of the horizontal shifting)
- press `K`, enter the value bigger than half of the screen. for me the screen length is 210 symbols, so I enter e.g. 110.
- press right arrow key
- and here it is: the last symbols (from colored range) in the longest line replaced with some hidden symbols from the rest parts of the current line.

here is how I solved this problem. please, take a look