### PR TITLE
proper home path expanding

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -89,9 +89,8 @@ func GetHomeDir() string {
 }
 
 func ExpandHomePath(path string) string {
-	if len(path) == 0 || path[0] != '~' {
+	if len(path) < 2 || path[:2] != "~"+string(os.PathSeparator) {
 		return path
 	}
-
-	return filepath.Join(GetHomeDir(), path[1:])
+	return filepath.Join(GetHomeDir(), path[2:])
 }


### PR DESCRIPTION
I found that if you open some file, press ctrl-s and type something like "\~some_filtered" as filtered file name, slit makes file "some_filtered" in the user's home directory. In order to create file with prefix "~" you must type relative ("./") or full path to the current directory.
I suggest another, more precise, way to expand the user's home path symbol - with directory separator only.