### PR TITLE
Ansi attribute updates

### DIFF
--- a/ansi/arune.go
+++ b/ansi/arune.go
@@ -100,6 +100,10 @@ mainLoop:
 				continue
 				// Control sequence
 			}
+			if rr[i+1] == 40 || rr[i+1] == 41 { // [27 {40,41}] is charset shift sequence, ignore
+				i += 2 // all shift sequences are two bytes
+				continue
+			}
 		} else if r == 8 { // CTRL+H/Backspace
 			if i > 0 && len(rr) > i+1 {
 				prevChar := rr[i-1]

--- a/term.go
+++ b/term.go
@@ -196,7 +196,6 @@ func ToTermboxAttr(attr ansi.RuneAttr) (fg, bg termbox.Attribute) {
 	}
 
 	fg = fg | style
-	bg = bg | style
 
 	return fg, bg
 }


### PR DESCRIPTION
* Ignore charset shift sequences that a normally sent with a `tput sgr0` reset (most commonly `(B`)
* Draw characters with bold+normal color attributes as "light" colors. fixes #38  