### PR TITLE
Refactor for library use

### DIFF
--- a/core/fetcher.go
+++ b/core/fetcher.go
@@ -1,4 +1,4 @@
-package main
+package core
 
 import (
 	"bufio"

--- a/core/infobar.go
+++ b/core/infobar.go
@@ -1,4 +1,4 @@
-package main
+package core
 
 import (
 	"bufio"

--- a/core/keyboard.go
+++ b/core/keyboard.go
@@ -1,4 +1,4 @@
-package main
+package core
 
 import (
 	"github.com/nsf/termbox-go"

--- a/core/main.go
+++ b/core/main.go
@@ -54,6 +54,7 @@ func (c *Config) isStdinRead() bool {
 	}
 }
 
+// Slit is a configured instance of the pager, ready to be displayed
 type Slit struct {
 	wg          sync.WaitGroup
 	ctx         context.Context
@@ -74,8 +75,8 @@ func (s *Slit) SetKeepChars(i int) { config.keepChars = i }
 // Set initial filters
 func (s *Slit) SetFilters(f []*filters.Filter) { config.initFilters = f }
 
+// Invoke the Slit UI
 func (s *Slit) Display() {
-	defer s.Shutdown()
 	v := &viewer{
 		fetcher:   newFetcher(s.file),
 		ctx:       s.ctx,
@@ -83,10 +84,12 @@ func (s *Slit) Display() {
 		filters:   config.initFilters,
 	}
 	v.termGui()
-	s.cancel()
 }
 
+// Shutdown and cleanup this pager instance. After instance shutdown,
+// it cannot be displayed again
 func (s *Slit) Shutdown() {
+	s.cancel()
 	s.wg.Wait()
 	s.file.Close()
 	if s.isCacheFile {

--- a/core/term.go
+++ b/core/term.go
@@ -1,4 +1,4 @@
-package main
+package core
 
 import (
 	"bufio"

--- a/core/viewbuffer.go
+++ b/core/viewbuffer.go
@@ -1,4 +1,4 @@
-package main
+package core
 
 import (
 	"context"

--- a/main.go
+++ b/main.go
@@ -78,6 +78,7 @@ func main() {
 	s.SetKeepChars(keepChars)
 
 	s.Display()
+	s.Shutdown()
 }
 
 func exitOnErr(err error) {

--- a/main.go
+++ b/main.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	flag "github.com/ogier/pflag"
+	"github.com/tigrawap/slit/core"
+	"github.com/tigrawap/slit/filters"
+	"github.com/tigrawap/slit/logging"
+)
+
+const VERSION = "1.1.6"
+
+var (
+	outPath    string
+	follow     bool
+	keepChars  int
+	filtersOpt string
+)
+
+func main() {
+
+	flag.StringVarP(&outPath, "output", "O", "", "Sets stdin cache location, if not set tmp file used, if set file preserved")
+	flag.BoolVar(&logging.Config.Enabled, "debug", false, "Enables debug messages, written to /tmp/slit.log")
+	flag.BoolVarP(&follow, "follow", "f", false, "Will follow file/stdin")
+	showVersion := false
+	flag.BoolVar(&showVersion, "version", false, "Print version")
+	flag.IntVarP(&keepChars, "keep-chars", "K", 0, "Initial num of chars kept during horizontal scrolling")
+	flag.StringVarP(&filtersOpt, "filters", "", "", "Filters file names or inline filters separated by semicolon")
+	flag.Parse()
+
+	if showVersion {
+		fmt.Println("Slit Version: ", VERSION)
+		os.Exit(0)
+	}
+
+	stdinStat, _ := os.Stdin.Stat()
+	stdoutStat, _ := os.Stdout.Stat()
+
+	var s *core.Slit
+	var err error
+
+	if isPipe(stdinStat) && flag.NArg() == 0 {
+		if isPipe(stdoutStat) {
+			outputToStdout(os.Stdin)
+			return
+		}
+		s, err = core.NewFromStdin()
+		exitOnErr(err)
+	} else {
+		if flag.NArg() != 1 {
+			fmt.Fprintln(os.Stderr, "Only viewing of one file or from STDIN is supported")
+			os.Exit(1)
+		}
+		path := flag.Arg(0)
+
+		if isPipe(stdoutStat) {
+			f, err := os.Open(path)
+			exitOnErr(err)
+			outputToStdout(f)
+			return
+		}
+
+		s, err = core.NewFromFilepath(path)
+		exitOnErr(err)
+	}
+
+	if filtersOpt != "" {
+		initFilters, err := filters.ParseFiltersOpt(filtersOpt)
+		exitOnErr(err)
+		s.SetFilters(initFilters)
+	}
+
+	s.SetOutPath(outPath)
+	s.SetFollow(follow)
+	s.SetKeepChars(keepChars)
+
+	s.Display()
+}
+
+func exitOnErr(err error) {
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func outputToStdout(file *os.File) {
+	io.Copy(os.Stdout, file)
+}
+
+func isPipe(info os.FileInfo) bool {
+	if info == nil {
+		return false
+	}
+	return (info.Mode() & os.ModeCharDevice) == 0
+}

--- a/slit.go
+++ b/slit.go
@@ -53,7 +53,6 @@ func (c *Config) isStdinRead() bool {
 	default:
 		return false
 	}
-
 }
 
 type Slit struct {
@@ -96,16 +95,9 @@ func New(f *os.File) (*Slit, error) {
 }
 
 func NewFromStdin() (*Slit, error) {
-	var err error
-	var cacheFile *os.File
-
-	if config.outPath == "" {
-		cacheFile, err = ioutil.TempFile(os.TempDir(), "slit_")
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		cacheFile = utils.OpenRewrite(config.outPath)
+	cacheFile, err := mkCacheFile()
+	if err != nil {
+		return nil, err
 	}
 
 	f, err := os.Open(cacheFile.Name())
@@ -206,6 +198,15 @@ func main() {
 	}
 
 	s.Display()
+}
+
+func mkCacheFile() (f *os.File, err error) {
+	if config.outPath == "" {
+		f, err = ioutil.TempFile(os.TempDir(), "slit_")
+	} else {
+		f = utils.OpenRewrite(config.outPath)
+	}
+	return f, err
 }
 
 func exitOnErr(err error) {


### PR DESCRIPTION
This PR refactors main `slit` components into a core subpackage suitable for import and use by external programs. Also introduced is a new `Slit` struct and some "entrypoint" methods for instantiation; e.g:

opening a viewer for a given filepath:
```go
package main

import (
	slit "github.com/tigrawap/slit/core"
)

func main() {
	s, err := slit.NewFromFilepath("/tmp/output.log")
	if err != nil {
		panic(err)
	}
	s.Display()
	s.Shutdown()
}
```

streaming from a channel to the viewer:
```go
package main

import (
	"fmt"
	"time"
	slit "github.com/tigrawap/slit/core"
)

func main() {
	ch := make(chan string)

	s, err := slit.NewFromStream(ch)
	if err != nil {
		panic(err)
	}

	go func() {
		for i := 0; i < 100; i++ {
			ch <- fmt.Sprintf("line %d", i)
			time.Sleep(10 * time.Millisecond)
		}
		close(ch)
	}()

	s.Display()
	s.Shutdown()
}
``` 

mostly closes https://github.com/tigrawap/slit/issues/45