### PR TITLE
prevent race conditions

### DIFF
--- a/fetcher.go
+++ b/fetcher.go
@@ -24,6 +24,7 @@ type Fetcher struct {
 	lineReaderPos    int
 	filters          []*filters.Filter
 	filtersEnabled   bool
+	filtersLock      sync.RWMutex
 }
 
 const (
@@ -67,7 +68,10 @@ func (a offsetArr) Less(i, j int) bool { return a[i] < a[j] }
 // Line == -1 if Line is excluded
 func (f *Fetcher) filteredLine(l PosLine) Line {
 	str := ansi.NewAstring(l.b)
-	if len(f.filters) == 0 || !f.filtersEnabled {
+	f.filtersLock.Lock()
+	filtersLen := len(f.filters)
+	f.filtersLock.Unlock()
+	if filtersLen == 0 || !f.filtersEnabled {
 		return Line{str, l.Pos}
 	}
 	var action filters.FilterResult

--- a/slit.go
+++ b/slit.go
@@ -96,7 +96,9 @@ func (s *Slit) Display() {
 
 	s.file.Seek(0, io.SeekStart)
 	//s.fetcher = newFetcher(s.file, s.ctx)
+	s.fetcher.filtersLock.Lock()
 	s.fetcher.filters = config.initFilters
+	s.fetcher.filtersLock.Unlock()
 	s.fetcher.seek(0)
 	s.initialised = true
 	v := &viewer{


### PR DESCRIPTION
hi!
the command `go run -race cmd/slit/main.go -- ...` with the large file as an argument outputs the following data race warnings:
```
==================
WARNING: DATA RACE
Read at 0x00c4200bc0d8 by goroutine 74:
  github.com/tigrawap/slit.(*Fetcher).filteredLine()
      /home/dv/godir/src/github.com/tigrawap/slit/fetcher.go:70 +0xea
  github.com/tigrawap/slit.(*Fetcher).lineBuilder.func1.2()
      /home/dv/godir/src/github.com/tigrawap/slit/fetcher.go:192 +0x7d

Previous write at 0x00c4200bc0d8 by main goroutine:
  github.com/tigrawap/slit.(*Slit).Display()
      /home/dv/godir/src/github.com/tigrawap/slit/slit.go:99 +0xaa
  main.main()
      /home/dv/godir/src/github.com/tigrawap/slit/cmd/slit/main.go:96 +0x66e

Goroutine 74 (running) created at:
  github.com/tigrawap/slit.(*Fetcher).lineBuilder.func1()
      /home/dv/godir/src/github.com/tigrawap/slit/fetcher.go:191 +0x455
==================
Found 1 data race(s)
exit status 66

==================
WARNING: DATA RACE
Read at 0x00c4200bc0d8 by goroutine 90:
  github.com/tigrawap/slit.(*Fetcher).filteredLine()
      /home/dv/godir/src/github.com/tigrawap/slit/fetcher.go:70 +0xea
  github.com/tigrawap/slit.(*Fetcher).lineBuilder.func1.2()
      /home/dv/godir/src/github.com/tigrawap/slit/fetcher.go:192 +0x7d

Previous write at 0x00c4200bc0d8 by main goroutine:
  github.com/tigrawap/slit.(*Slit).Display()
      /home/dv/godir/src/github.com/tigrawap/slit/slit.go:99 +0xaa
  main.main()
      /home/dv/godir/src/github.com/tigrawap/slit/cmd/slit/main.go:96 +0x66e

Goroutine 90 (running) created at:
  github.com/tigrawap/slit.(*Fetcher).lineBuilder.func1()
      /home/dv/godir/src/github.com/tigrawap/slit/fetcher.go:191 +0x455
==================
==================
WARNING: DATA RACE
Read at 0x00c4200bc0c0 by goroutine 12:
  github.com/tigrawap/slit.(*Fetcher).readline()
      /home/dv/godir/src/github.com/tigrawap/slit/fetcher.go:133 +0x5c
  github.com/tigrawap/slit.(*Fetcher).Get.func1()
      /home/dv/godir/src/github.com/tigrawap/slit/fetcher.go:226 +0xbd

Previous write at 0x00c4200bc0c0 by main goroutine:
  github.com/tigrawap/slit.(*Fetcher).seek()
      /home/dv/godir/src/github.com/tigrawap/slit/fetcher.go:127 +0x1fb
  github.com/tigrawap/slit.(*Slit).Display()
      /home/dv/godir/src/github.com/tigrawap/slit/slit.go:100 +0x11f
  main.main()
      /home/dv/godir/src/github.com/tigrawap/slit/cmd/slit/main.go:96 +0x66e

Goroutine 12 (running) created at:
  github.com/tigrawap/slit.(*Fetcher).Get()
      /home/dv/godir/src/github.com/tigrawap/slit/fetcher.go:222 +0x1f1
  github.com/tigrawap/slit.(*Slit).CanFitDisplay()
      /home/dv/godir/src/github.com/tigrawap/slit/slit.go:264 +0x138
  main.tryDirectOutputIfShort()
      /home/dv/godir/src/github.com/tigrawap/slit/cmd/slit/main.go:102 +0xb0
  main.main()
      /home/dv/godir/src/github.com/tigrawap/slit/cmd/slit/main.go:81 +0x7ae
```

Here is my attempt to prevent such behavior, PTAL. Maybe it's awkward or the wrong way, so I'm waiting for your comments.