### PR TITLE
Avoid division by zero

### DIFF
--- a/slit.go
+++ b/slit.go
@@ -260,6 +260,9 @@ func (s *Slit) CanFitDisplay(ctx context.Context) bool {
 	termbox.Init()
 	w, h := termbox.Size()
 	termbox.Close()
+	if w == 0 || h == 0 {
+		return false
+	}
 	localCtx, cancel := context.WithCancel(ctx)
 	parsedLineCount := 0
 	lines := s.fetcher.Get(localCtx, Pos{})


### PR DESCRIPTION
In some environments, termbox returns the width as 0 causing a
segmentation fault when trying to calculate if the content fits
the terminal screen.

Avoid the division by zero for now while the specific conditions in
which this zero value is produced are clarified.