### PR TITLE
Avoid 'index out of range' panic

### DIFF
--- a/ansi/arune.go
+++ b/ansi/arune.go
@@ -100,7 +100,7 @@ mainLoop:
 				continue
 				// Control sequence
 			}
-			if rr[i+1] == 40 || rr[i+1] == 41 { // [27 {40,41}] is charset shift sequence, ignore
+			if i != max -1 && (rr[i+1] == 40 || rr[i+1] == 41) { // [27 {40,41}] is charset shift sequence, ignore
 				i += 2 // all shift sequences are two bytes
 				continue
 			}


### PR DESCRIPTION
When parsing some escape characters, slit was panicking with an 'index
out of range' error:

  goroutine 207 [running]:
  ff/slit/ansi.NewAstring(0xc0001881c8, 0x4, 0x5, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
  /opt/klm-go/src/ff/slit/ansi/arune.go:78 +0x36d
  ff/slit.(*Fetcher).filteredLine(0xc000010180, 0xc0001881c8, 0x4, 0x5, 0x97, 0x1a6a, 0x0, 0x0, 0x0, 0x0, ...)
  /opt/klm-go/src/ff/slit/fetcher.go:72 +0x80
  ff/slit.(*Fetcher).lineBuilder.func1.2(0xc000010180, 0xc00022e000, 0x100, 0x100, 0xc000188110, 0x97, 0xc0001881c8, 0x4, 0x5, 0x97, ...)
  /opt/klm-go/src/ff/slit/fetcher.go:198 +0x67
  created by ff/slit.(*Fetcher).lineBuilder.func1
  /opt/klm-go/src/ff/slit/fetcher.go:197 +0x31e
  panic: runtime error: index out of range

Check boundary values when handling escape characters to avoid this
issue.