### PR TITLE
Show a message when didn't find a searching text

### DIFF
--- a/term.go
+++ b/term.go
@@ -71,6 +71,8 @@ func (v *viewer) searchForward() {
 	if pos := v.fetcher.Search(context.TODO(), v.buffer.lastLine().Pos, searchFunc); pos != POS_NOT_FOUND {
 		v.buffer.reset(pos)
 		v.draw()
+	} else {
+		v.info.setMessage(ibMessage{str: fmt.Sprintf("'%s' not found", string(v.search)), color: termbox.ColorRed})
 	}
 }
 
@@ -102,6 +104,8 @@ func (v *viewer) searchBack() {
 	if pos := v.fetcher.SearchBack(context.TODO(), fromPos, searchFunc); pos != POS_NOT_FOUND {
 		v.buffer.reset(pos)
 		v.draw()
+	} else {
+		v.info.setMessage(ibMessage{str: fmt.Sprintf("'%s' not found", string(v.search)), color: termbox.ColorRed})
 	}
 }
 


### PR DESCRIPTION
Currently, `slit` does nothing when didn't find a searching text. Sometimes this makes me confusing that the search is over or still doing.

This fix is to show a message when didn't find a searching text. I think this helps users to understand the result of searching.
